### PR TITLE
fix: NXDomain should continue to next server if available

### DIFF
--- a/ARSoft.Tools.Net/ARSoft.Tools.Net.csproj
+++ b/ARSoft.Tools.Net/ARSoft.Tools.Net.csproj
@@ -16,7 +16,7 @@
 		<PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
 		<PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
 		<Copyright>Copyright 2010..2024 Alexander Reinert</Copyright>
-		<VersionPrefix>3.6.1</VersionPrefix>
+		<VersionPrefix>3.6.2</VersionPrefix>
 		<AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
 		<Platforms>AnyCPU;x64;ARM64</Platforms>
 	</PropertyGroup>

--- a/ARSoft.Tools.Net/Dns/DnsClientBase.cs
+++ b/ARSoft.Tools.Net/Dns/DnsClientBase.cs
@@ -157,7 +157,7 @@ namespace ARSoft.Tools.Net.Dns
                     {
                         connection.RestartIdleTimeout(receivedMessage.Message.GetEDnsKeepAliveTimeout());
 
-                        if (receivedMessage.Message.ReturnCode == ReturnCode.ServerFailure)
+                        if (receivedMessage.Message.ReturnCode is ReturnCode.ServerFailure or ReturnCode.NxDomain)
                         {
                             response = receivedMessage.Message;
                             continue;


### PR DESCRIPTION
The current ARSoft code conisders NXDomain a valid response and does not try the remaining DNS resolvers. This is different than how the winRC currently works with the old library so this change makes the library continue to try all the servers and only return NXDomain if no other response is available