### PR TITLE
Improved Logging

### DIFF
--- a/ARSoft.Tools.Net/Dns/DnsClient.cs
+++ b/ARSoft.Tools.Net/Dns/DnsClient.cs
@@ -27,7 +27,9 @@ using System.Net.Sockets;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using ARSoft.Tools.Net.Dns.Dnsf;
 using ARSoft.Tools.Net.Dns.DynamicUpdate;
+using Microsoft.Extensions.Logging;
 
 namespace ARSoft.Tools.Net.Dns
 {
@@ -41,7 +43,7 @@ namespace ARSoft.Tools.Net.Dns
 		///   query timeout of 10 seconds.
 		/// </summary>
 		public static DnsClient Default { get; private set; }
-
+        private readonly ILogger _logger;
 		static DnsClient()
 		{
 			Default = new DnsClient(GetLocalConfiguredDnsServers(), 10000) { IsResponseValidationEnabled = true };
@@ -61,7 +63,10 @@ namespace ARSoft.Tools.Net.Dns
 		/// <param name="dnsServers"> The IPAddresses of the dns servers to use </param>
 		/// <param name="queryTimeout"> Query timeout in milliseconds </param>
 		public DnsClient(IEnumerable<IPAddress> dnsServers, int queryTimeout = 10000)
-			: base(dnsServers, queryTimeout, new IClientTransport[] { new UdpClientTransport(), new TcpClientTransport() }, true) { }
+			: base(dnsServers, queryTimeout, new IClientTransport[] { new UdpClientTransport(), new TcpClientTransport() }, true)
+        {
+            _logger = DnsfLogging.LoggerFactory.CreateLogger<DnsClient>();
+        }
 
 		/// <summary>
 		///   Provides a new instance with custom dns servers and query timeout
@@ -74,17 +79,20 @@ namespace ARSoft.Tools.Net.Dns
 		/// </param>
 		/// <param name="queryTimeout"> Query timeout in milliseconds </param>
 		public DnsClient(IEnumerable<IPAddress> dnsServers, IClientTransport[] transports, bool disposeTransport = false, int queryTimeout = 10000)
-			: base(dnsServers, queryTimeout, transports, disposeTransport) { }
+			: base(dnsServers, queryTimeout, transports, disposeTransport)
+        {
+            _logger = DnsfLogging.LoggerFactory.CreateLogger<DnsClient>();
+        }
 
-		/// <summary>
-		///   Queries a dns server for specified records.
-		/// </summary>
-		/// <param name="name"> Domain, that should be queried </param>
-		/// <param name="recordType"> Type the should be queried </param>
-		/// <param name="recordClass"> Class the should be queried </param>
-		/// <param name="options"> Options for the query </param>
-		/// <returns> The complete response of the dns server </returns>
-		public DnsMessage? Resolve(DomainName name, RecordType recordType = RecordType.A, RecordClass recordClass = RecordClass.INet, DnsQueryOptions? options = null)
+        /// <summary>
+        ///   Queries a dns server for specified records.
+        /// </summary>
+        /// <param name="name"> Domain, that should be queried </param>
+        /// <param name="recordType"> Type the should be queried </param>
+        /// <param name="recordClass"> Class the should be queried </param>
+        /// <param name="options"> Options for the query </param>
+        /// <returns> The complete response of the dns server </returns>
+        public DnsMessage? Resolve(DomainName name, RecordType recordType = RecordType.A, RecordClass recordClass = RecordClass.INet, DnsQueryOptions? options = null)
 		{
 			_ = name ?? throw new ArgumentNullException(nameof(name), "Name must be provided");
 

--- a/ARSoft.Tools.Net/Dns/DnsClientBase.cs
+++ b/ARSoft.Tools.Net/Dns/DnsClientBase.cs
@@ -18,6 +18,8 @@
 
 #endregion
 
+using ARSoft.Tools.Net.Dns.Dnsf;
+using Microsoft.Extensions.Logging;
 using Org.BouncyCastle.Crypto.Prng;
 using Org.BouncyCastle.Security;
 using System.Collections.Concurrent;
@@ -51,15 +53,18 @@ namespace ARSoft.Tools.Net.Dns
 
         private readonly IClientTransport[] _transports;
         private readonly bool _disposeTransports;
+        private readonly string _clientId;
+        private readonly ILogger _logger;
 
         internal DnsClientBase(IEnumerable<IPAddress> servers, int queryTimeout, IClientTransport[] transports,
             bool disposeTransports)
         {
             QueryTimeout = queryTimeout;
-
+            _logger = DnsfLogging.LoggerFactory.CreateLogger(nameof(DnsClientBase));
             _transports = transports;
             _disposeTransports = disposeTransports;
-
+            _clientId = Guid.NewGuid().ToString();
+            _logger.LogDnsClientInitialized(_clientId, servers, queryTimeout, transports.Select(t => t.GetType().Name));
             _endpointInfos = GetEndpointInfos(servers);
         }
 
@@ -98,7 +103,10 @@ namespace ARSoft.Tools.Net.Dns
         {
             if (IsResponseValidationEnabled)
             {
-                message.ValidateResponse(response);
+                // This library is all sorts of janky. This will "validate" but it will NEVER return that a response ISN'T valid.
+                // We modify this just for logging purposes, but the original just calls message.ValidateResponse(response) without checking its result.
+                var result = message.ValidateResponse(response);
+                _logger.LogResponseMessageValidationResult(_clientId, message.TransactionID, result);
             }
 
             return true;
@@ -111,15 +119,17 @@ namespace ARSoft.Tools.Net.Dns
             if (message.TransactionID == 0)
             {
                 message.TransactionID = (ushort)_secureRandom.Next(1, 0xffff);
+                _logger.LogRequestTransactionIdMissing(_clientId, message.TransactionID);
             }
 
+            _logger.LogRequest0x20ValidationStatus(_clientId, message.TransactionID, Is0x20ValidationEnabled);
             if (Is0x20ValidationEnabled)
             {
                 message.Add0x20Bits();
             }
 
             var package = message.Encode(null, false, out tsigOriginalMac);
-
+            _logger.LogRequestSecretKeyTransactionAuthenticationStatus(_clientId, message.TransactionID, message.TSigOptions is not null);
             if (message.TSigOptions != null)
             {
                 tsigKeySelector = (_, _, _) => message.TSigOptions!.KeyData;
@@ -138,7 +148,6 @@ namespace ARSoft.Tools.Net.Dns
             var package = PrepareMessage(query, out var tsigKeySelector, out var tsigOriginalMac);
 
             TMessage? response = null;
-
             foreach (var connectionTask in GetConnectionTasks(package, query.IsReliableSendingRequested, token))
             {
                 IClientConnection? connection = null;
@@ -148,7 +157,10 @@ namespace ARSoft.Tools.Net.Dns
                     connection = await connectionTask;
 
                     if (connection == null)
+                    {
+                        _logger.LogRequestFailedMissingConnection(_clientId, query.TransactionID);
                         continue;
+                    }
 
                     var receivedMessage = await SendMessageAsync<TMessage>(package, connection, tsigKeySelector,
                         tsigOriginalMac, token);
@@ -159,12 +171,16 @@ namespace ARSoft.Tools.Net.Dns
 
                         if (receivedMessage.Message.ReturnCode is ReturnCode.ServerFailure or ReturnCode.NxDomain)
                         {
+                            _logger.LogRequestFailedBadReturnCode(_clientId, query.TransactionID, (ushort)receivedMessage.Message.ReturnCode);
                             response = receivedMessage.Message;
                             continue;
                         }
 
                         if (!receivedMessage.Message.IsReliableResendingRequested)
+                        {
+                            _logger.LogResponseSuccessful(_clientId, query.TransactionID);
                             return receivedMessage.Message;
+                        }
 
                         var resendTransport = _transports.FirstOrDefault(t =>
                             t.SupportsReliableTransfer && t.MaximumAllowedQuerySize <= package.Length &&
@@ -172,12 +188,14 @@ namespace ARSoft.Tools.Net.Dns
 
                         if (resendTransport != null)
                         {
+                            _logger.LogRequestReattemptWithReliableTransportRequested(_clientId, query.TransactionID, resendTransport.GetType().Name);
                             using (var resendConnection = await resendTransport.ConnectAsync(
                                        new DnsClientEndpointInfo(false, receivedMessage.ResponderAddress.Address,
                                            receivedMessage.LocalAddress.Address), QueryTimeout, token))
                             {
                                 if (resendConnection == null)
                                 {
+                                    _logger.LogRequestFailedReattemptOverReliableTransportConnectionNotAvailable(_clientId, query.TransactionID);
                                     response = receivedMessage.Message;
                                 }
                                 else
@@ -189,26 +207,34 @@ namespace ARSoft.Tools.Net.Dns
                                         && ValidateResponse(query, resendResponse.Message)
                                         && ((resendResponse.Message.ReturnCode != ReturnCode.ServerFailure)))
                                     {
+                                        _logger.LogResponseSuccessfulOverReliableTransport(_clientId, query.TransactionID);
                                         resendConnection.RestartIdleTimeout(receivedMessage.Message
                                             .GetEDnsKeepAliveTimeout());
                                         return resendResponse.Message;
                                     }
                                     else
                                     {
+                                        _logger.LogRequestFailedReattemptOverReliableTransportResponseMissingOrInvalid(_clientId, query.TransactionID);
                                         resendConnection.MarkFaulty();
                                         response = receivedMessage.Message;
                                     }
                                 }
                             }
                         }
+                        else
+                        {
+                            _logger.LogRequestFailedReattemptOverReliableTransportNotAvailable(_clientId, query.TransactionID);
+                        }
                     }
                     else
                     {
+                        _logger.LogRequestFailedResponseMissingOrInvalid(_clientId, query.TransactionID);
                         connection.MarkFaulty();
                     }
                 }
                 catch (Exception e)
                 {
+                    _logger.LogRequestFailedConnectionException(e, _clientId, query.TransactionID);
                     Trace.TraceError("Error on dns query: " + e);
                     connection?.MarkFaulty();
                 }
@@ -224,6 +250,7 @@ namespace ARSoft.Tools.Net.Dns
         private IEnumerable<Task<IClientConnection?>> GetConnectionTasks(DnsRawPackage package,
             bool isReliableTransportRequested, CancellationToken token)
         {
+            int requestAttempt = 1;
             foreach (var transport in _transports)
             {
                 if (transport.SupportsPooledConnections
@@ -232,7 +259,9 @@ namespace ARSoft.Tools.Net.Dns
                 {
                     foreach (var endpointInfo in _endpointInfos)
                     {
+                        _logger.LogConnectionAttemptWithPooledConnection(_clientId, package.MessageIdentification.TransactionID, requestAttempt, endpointInfo.DestinationAddress, transport.GetType().Name);
                         yield return transport.GetPooledConnectionAsync(endpointInfo, token);
+                        requestAttempt++;
                     }
                 }
             }
@@ -244,7 +273,9 @@ namespace ARSoft.Tools.Net.Dns
                 {
                     foreach (var endpointInfo in _endpointInfos)
                     {
+                        _logger.LogConnectionAttemptWithReliableConnection(_clientId, package.MessageIdentification.TransactionID, requestAttempt, endpointInfo.DestinationAddress, transport.GetType().Name);
                         yield return transport.ConnectAsync(endpointInfo, QueryTimeout, token);
+                        requestAttempt++;
                     }
                 }
             }
@@ -256,12 +287,18 @@ namespace ARSoft.Tools.Net.Dns
             where TMessage : DnsMessageBase, new()
         {
             if (!await connection.SendAsync(package, token))
+            {
+                _logger.LogConnectionRequestSendingFailed(_clientId, package.MessageIdentification.TransactionID, connection.GetType().Name);
                 return null;
+            }
 
             var resultData = await connection.ReceiveAsync(package.MessageIdentification, token);
 
             if (resultData == null)
+            {
+                _logger.LogConnectionResponseReceivingFailed(_clientId, package.MessageIdentification.TransactionID, connection.GetType().Name);
                 return null;
+            }
 
             var response =
                 DnsMessageBase.Parse<TMessage>(resultData.ToArraySegment(false), tsigKeySelector, tsigOriginalMac);
@@ -270,16 +307,23 @@ namespace ARSoft.Tools.Net.Dns
 
             while (isNextMessageWaiting)
             {
+                _logger.LogConnectionResponseIndicatesFurtherMessages(_clientId, package.MessageIdentification.TransactionID);
                 resultData = await connection.ReceiveAsync(package.MessageIdentification, token);
 
                 if (resultData == null)
+                {
+                    _logger.LogConnectionSubsequentResponseMissing(_clientId, package.MessageIdentification.TransactionID);
                     return null;
+                }
 
                 var nextResult = DnsMessageBase.Parse<TMessage>(resultData.ToArraySegment(false), tsigKeySelector,
                     tsigOriginalMac);
 
                 if (nextResult.ReturnCode == ReturnCode.ServerFailure)
+                {
+                    _logger.LogConnectionSubsequentResponseIndicatesServerFailure(_clientId, package.MessageIdentification.TransactionID);
                     return null;
+                }
 
                 response.AddSubsequentResponse(nextResult);
                 isNextMessageWaiting = nextResult.IsNextMessageWaiting(true);
@@ -403,11 +447,13 @@ namespace ARSoft.Tools.Net.Dns
                 }
                 else
                 {
+                    _logger.LogRequestFailedResponseMissingOrInvalid(_clientId, query.TransactionID);
                     connection?.MarkFaulty();
                 }
             }
             catch (Exception e)
             {
+                _logger.LogRequestFailedConnectionException(e, _clientId, query.TransactionID);
                 Trace.TraceError("Error on dns query: " + e);
                 connection?.MarkFaulty();
             }
@@ -491,6 +537,7 @@ namespace ARSoft.Tools.Net.Dns
         {
             if (_disposeTransports)
             {
+                _logger.LogDnsClientDisposed(_clientId);
                 foreach (var transport in _transports)
                 {
                     transport.Dispose();

--- a/ARSoft.Tools.Net/Dns/Dnsf/DnsfLogging.cs
+++ b/ARSoft.Tools.Net/Dns/Dnsf/DnsfLogging.cs
@@ -1,0 +1,15 @@
+﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace ARSoft.Tools.Net.Dns.Dnsf;
+
+/// <summary>
+/// Allows logging within the library.
+/// </summary>
+public static class DnsfLogging
+{
+    /// <summary>
+    /// Contains the logger factory in use by the library, since ARSoft does not support logging or DI.
+    /// </summary>
+    public static ILoggerFactory LoggerFactory { get; set; } = NullLoggerFactory.Instance;
+}

--- a/ARSoft.Tools.Net/Dns/Dnsf/ILoggerExtensions.cs
+++ b/ARSoft.Tools.Net/Dns/Dnsf/ILoggerExtensions.cs
@@ -17,7 +17,7 @@ internal static partial class ILoggerExtensions
     [LoggerMessage(EventId = 2, Level = LogLevel.Trace, Message = "[{ClientId}:{TransactionId}] Request 0x20 Validation Enabled = {Is0x20ValidationEnabled}.")]
     public static partial void LogRequest0x20ValidationStatus(this ILogger logger, string clientId, ushort transactionId, bool is0x20ValidationEnabled);
 
-    [LoggerMessage(EventId = 3, Level = LogLevel.Trace, Message = "[{ClientId}:{TransactionId}] Request Secret Key Transaction Authentcation Enabled = {SecretKeyTransactionAuthenticationEnabled}.")]
+    [LoggerMessage(EventId = 3, Level = LogLevel.Trace, Message = "[{ClientId}:{TransactionId}] Request Secret Key Transaction Authentication Enabled = {SecretKeyTransactionAuthenticationEnabled}.")]
     public static partial void LogRequestSecretKeyTransactionAuthenticationStatus(this ILogger logger, string clientId, ushort transactionId, bool secretKeyTransactionAuthenticationEnabled);
 
     [LoggerMessage(EventId = 4, Level = LogLevel.Warning, Message = "[{ClientId}:{TransactionId}] Response Validation Successful: {ResponseValidationSuccessful}.")]

--- a/ARSoft.Tools.Net/Dns/Dnsf/ILoggerExtensions.cs
+++ b/ARSoft.Tools.Net/Dns/Dnsf/ILoggerExtensions.cs
@@ -1,0 +1,76 @@
+﻿using Microsoft.Extensions.Logging;
+using System.Net;
+
+namespace ARSoft.Tools.Net.Dns.Dnsf;
+
+internal static partial class ILoggerExtensions
+{
+    [LoggerMessage(EventId = -1, Level = LogLevel.Debug, Message = "[{ClientId}] Disposing Client.")]
+    public static partial void LogDnsClientDisposed(this ILogger logger, string clientId);
+
+    [LoggerMessage(EventId = 0, Level = LogLevel.Debug, Message = "[{ClientId}] Initialized DNS Client with Timeout {QueryTimeoutInSeconds} and Servers {Servers}. Transports are {TransportNames}.")]
+    public static partial void LogDnsClientInitialized(this ILogger logger, string clientId, IEnumerable<IPAddress> servers, int queryTimeoutInSeconds, IEnumerable<string> transportNames);
+
+    [LoggerMessage(EventId = 1, Level = LogLevel.Warning, Message = "[{ClientId}:{TransactionId}] Request is missing a Transaction ID. Will assign randomly generated value {TransactionId}.")]
+    public static partial void LogRequestTransactionIdMissing(this ILogger logger, string clientId, ushort transactionId);
+
+    [LoggerMessage(EventId = 2, Level = LogLevel.Trace, Message = "[{ClientId}:{TransactionId}] Request 0x20 Validation Enabled = {Is0x20ValidationEnabled}.")]
+    public static partial void LogRequest0x20ValidationStatus(this ILogger logger, string clientId, ushort transactionId, bool is0x20ValidationEnabled);
+
+    [LoggerMessage(EventId = 3, Level = LogLevel.Trace, Message = "[{ClientId}:{TransactionId}] Request Secret Key Transaction Authentcation Enabled = {SecretKeyTransactionAuthenticationEnabled}.")]
+    public static partial void LogRequestSecretKeyTransactionAuthenticationStatus(this ILogger logger, string clientId, ushort transactionId, bool secretKeyTransactionAuthenticationEnabled);
+
+    [LoggerMessage(EventId = 4, Level = LogLevel.Warning, Message = "[{ClientId}:{TransactionId}] Response Validation Successful: {ResponseValidationSuccessful}.")]
+    public static partial void LogResponseMessageValidationResult(this ILogger logger, string clientId, ushort transactionId, bool responseValidationSuccessful);
+
+    [LoggerMessage(EventId = 5, Level = LogLevel.Error, Message = "[{ClientId}:{TransactionId}] Request Attempt failed due to an unknown error.")]
+    public static partial void LogRequestFailedConnectionException(this ILogger logger, Exception ex, string clientId, ushort transactionId);
+
+    [LoggerMessage(EventId = 6, Level = LogLevel.Error, Message = "[{ClientId}:{TransactionId}] Request Attempt failed due to a missing or invalid response.")]
+    public static partial void LogRequestFailedResponseMissingOrInvalid(this ILogger logger, string clientId, ushort transactionId);
+
+    [LoggerMessage(EventId = 7, Level = LogLevel.Debug, Message = "[{ClientId}:{TransactionId}] Request Attempt {RequestAttempt} to {DestinationAddress} using Pooled Transport {TransportName}.")]
+    public static partial void LogConnectionAttemptWithPooledConnection(this ILogger logger, string clientId, ushort transactionId, int requestAttempt, IPAddress destinationAddress, string transportName);
+
+    [LoggerMessage(EventId = 8, Level = LogLevel.Debug, Message = "[{ClientId}:{TransactionId}] Request Attempt {RequestAttempt} to {DestinationAddress} using Reliable Transport {TransportName}.")]
+    public static partial void LogConnectionAttemptWithReliableConnection(this ILogger logger, string clientId, ushort transactionId, int requestAttempt, IPAddress destinationAddress, string transportName);
+
+    [LoggerMessage(EventId = 9, Level = LogLevel.Warning, Message = "[{ClientId}:{TransactionId}] Request Attempt failed due to a missing connection.")]
+    public static partial void LogRequestFailedMissingConnection(this ILogger logger, string clientId, ushort transactionId);
+
+    [LoggerMessage(EventId = 10, Level = LogLevel.Warning, Message = "[{ClientId}:{TransactionId}] Request Attempt failed due to a bad result code: {ResultCode}.")]
+    public static partial void LogRequestFailedBadReturnCode(this ILogger logger, string clientId, ushort transactionId, ushort resultCode);
+
+    [LoggerMessage(EventId = 11, Level = LogLevel.Trace, Message = "[{ClientId}:{TransactionId}] Successfully received response.")]
+    public static partial void LogResponseSuccessful(this ILogger logger, string clientId, ushort transactionId);
+
+    [LoggerMessage(EventId = 12, Level = LogLevel.Trace, Message = "[{ClientId}:{TransactionId}] Request reattempt over reliable transport {TransportName}.")]
+    public static partial void LogRequestReattemptWithReliableTransportRequested(this ILogger logger, string clientId, ushort transactionId, string transportName);
+
+    [LoggerMessage(EventId = 13, Level = LogLevel.Error, Message = "[{ClientId}:{TransactionId}] Request Attempt failed due to no reliable transports available.")]
+    public static partial void LogRequestFailedReattemptOverReliableTransportNotAvailable(this ILogger logger, string clientId, ushort transactionId);
+
+    [LoggerMessage(EventId = 14, Level = LogLevel.Error, Message = "[{ClientId}:{TransactionId}] Request Attempt failed due to reliable transport connection not available.")]
+    public static partial void LogRequestFailedReattemptOverReliableTransportConnectionNotAvailable(this ILogger logger, string clientId, ushort transactionId);
+
+    [LoggerMessage(EventId = 15, Level = LogLevel.Error, Message = "[{ClientId}:{TransactionId}] Request Attempt failed due to reliable transport response missing or invalid.")]
+    public static partial void LogRequestFailedReattemptOverReliableTransportResponseMissingOrInvalid(this ILogger logger, string clientId, ushort transactionId);
+
+    [LoggerMessage(EventId = 16, Level = LogLevel.Trace, Message = "[{ClientId}:{TransactionId}] Successfully received response from reliable transport.")]
+    public static partial void LogResponseSuccessfulOverReliableTransport(this ILogger logger, string clientId, ushort transactionId);
+
+    [LoggerMessage(EventId = 17, Level = LogLevel.Error, Message = "[{ClientId}:{TransactionId}] Sending request over connection {ConnectionName} failed.")]
+    public static partial void LogConnectionRequestSendingFailed(this ILogger logger, string clientId, ushort transactionId, string connectionName);
+
+    [LoggerMessage(EventId = 18, Level = LogLevel.Error, Message = "[{ClientId}:{TransactionId}] Receiving response over connection {ConnectionName} failed.")]
+    public static partial void LogConnectionResponseReceivingFailed(this ILogger logger, string clientId, ushort transactionId, string connectionName);
+
+    [LoggerMessage(EventId = 19, Level = LogLevel.Trace, Message = "[{ClientId}:{TransactionId}] Received response that requires further messages.")]
+    public static partial void LogConnectionResponseIndicatesFurtherMessages(this ILogger logger, string clientId, ushort transactionId);
+
+    [LoggerMessage(EventId = 20, Level = LogLevel.Error, Message = "[{ClientId}:{TransactionId}] Unable to receive subsequent response after previous response.")]
+    public static partial void LogConnectionSubsequentResponseMissing(this ILogger logger, string clientId, ushort transactionId);
+
+    [LoggerMessage(EventId = 21, Level = LogLevel.Error, Message = "[{ClientId}:{TransactionId}] Unable to receive subsequent response due to server failure.")]
+    public static partial void LogConnectionSubsequentResponseIndicatesServerFailure(this ILogger logger, string clientId, ushort transactionId);
+}

--- a/ARSoft.Tools.Net/Dns/Dnsf/ILoggerExtensions.cs
+++ b/ARSoft.Tools.Net/Dns/Dnsf/ILoggerExtensions.cs
@@ -5,9 +5,6 @@ namespace ARSoft.Tools.Net.Dns.Dnsf;
 
 internal static partial class ILoggerExtensions
 {
-    [LoggerMessage(EventId = -1, Level = LogLevel.Debug, Message = "[{ClientId}] Disposing Client.")]
-    public static partial void LogDnsClientDisposed(this ILogger logger, string clientId);
-
     [LoggerMessage(EventId = 0, Level = LogLevel.Debug, Message = "[{ClientId}] Initialized DNS Client with Timeout {QueryTimeoutInSeconds} and Servers {Servers}. Transports are {TransportNames}.")]
     public static partial void LogDnsClientInitialized(this ILogger logger, string clientId, IEnumerable<IPAddress> servers, int queryTimeoutInSeconds, IEnumerable<string> transportNames);
 
@@ -73,4 +70,7 @@ internal static partial class ILoggerExtensions
 
     [LoggerMessage(EventId = 21, Level = LogLevel.Error, Message = "[{ClientId}:{TransactionId}] Unable to receive subsequent response due to server failure.")]
     public static partial void LogConnectionSubsequentResponseIndicatesServerFailure(this ILogger logger, string clientId, ushort transactionId);
+
+    [LoggerMessage(EventId = 22, Level = LogLevel.Debug, Message = "[{ClientId}] Disposing Client.")]
+    public static partial void LogDnsClientDisposed(this ILogger logger, string clientId);
 }

--- a/ARSoft.Tools.Net/Dns/Dnsf/ILoggerExtensions.cs
+++ b/ARSoft.Tools.Net/Dns/Dnsf/ILoggerExtensions.cs
@@ -17,7 +17,7 @@ internal static partial class ILoggerExtensions
     [LoggerMessage(EventId = 3, Level = LogLevel.Trace, Message = "[{ClientId}:{TransactionId}] Request Secret Key Transaction Authentication Enabled = {SecretKeyTransactionAuthenticationEnabled}.")]
     public static partial void LogRequestSecretKeyTransactionAuthenticationStatus(this ILogger logger, string clientId, ushort transactionId, bool secretKeyTransactionAuthenticationEnabled);
 
-    [LoggerMessage(EventId = 4, Level = LogLevel.Warning, Message = "[{ClientId}:{TransactionId}] Response Validation Successful: {ResponseValidationSuccessful}.")]
+    [LoggerMessage(EventId = 4, Level = LogLevel.Trace, Message = "[{ClientId}:{TransactionId}] Response Validation Successful: {ResponseValidationSuccessful}.")]
     public static partial void LogResponseMessageValidationResult(this ILogger logger, string clientId, ushort transactionId, bool responseValidationSuccessful);
 
     [LoggerMessage(EventId = 5, Level = LogLevel.Error, Message = "[{ClientId}:{TransactionId}] Request Attempt failed due to an unknown error.")]


### PR DESCRIPTION
This is a first-try towards improving logging on the ARSoft.Tools.Net library. I tried my best to keep our code separate from theirs, but it's kinda tricky when they have no logging whatsover. Honestly I'd love to get rid of this library one day lol.

There may be more log messages needed, but for starting off I figured these 21 log messages were enough. The basic idea is that by default nothing will change behavior-wise. An application that wants to have this library log messages can call the static DnsfLogging class and change the LoggerFactory to another logger factory based on DI or something else. This way the logging mechanism is abstracted away behind MEL and we only need to know how to generate a logger.

I also purposefully did not log the parallel queries as I don't think we use them for anything. If we do, please let me know and I'll add logs there too.

-----

feature(logging): Adding a mechanism to add log messages without relying on any specific implementation of logging. Added log messages to DnsClient and DnsClientBase.