### PR TITLE
fix(dns-client-base): RC-445 Fixing Log Namespace in DnsClientBase

### DIFF
--- a/ARSoft.Tools.Net/Dns/DnsClientBase.cs
+++ b/ARSoft.Tools.Net/Dns/DnsClientBase.cs
@@ -60,7 +60,7 @@ namespace ARSoft.Tools.Net.Dns
             bool disposeTransports)
         {
             QueryTimeout = queryTimeout;
-            _logger = DnsfLogging.LoggerFactory.CreateLogger(typeof(DnsClientBase).FullName!);
+            _logger = DnsfLogging.LoggerFactory.CreateLogger(typeof(DnsClientBase).FullName ?? nameof(DnsClientBase));
             _transports = transports;
             _disposeTransports = disposeTransports;
             _clientId = Guid.NewGuid().ToString();

--- a/ARSoft.Tools.Net/Dns/DnsClientBase.cs
+++ b/ARSoft.Tools.Net/Dns/DnsClientBase.cs
@@ -60,7 +60,7 @@ namespace ARSoft.Tools.Net.Dns
             bool disposeTransports)
         {
             QueryTimeout = queryTimeout;
-            _logger = DnsfLogging.LoggerFactory.CreateLogger(nameof(DnsClientBase));
+            _logger = DnsfLogging.LoggerFactory.CreateLogger(typeof(DnsClientBase).FullName!);
             _transports = transports;
             _disposeTransports = disposeTransports;
             _clientId = Guid.NewGuid().ToString();


### PR DESCRIPTION
fix(dns-client-base): Fixing the logger implementation to use the full namespace of the class instead of just the class name for logging filtering purposes.